### PR TITLE
Fixes setup.py and tox.ini to comply with requirements.txt flexible reps versioning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ setup(name='webpreview',
       include_package_data=True,
       zip_safe=True,
       install_requires=[
-        "requests==2.13.0",
-        "beautifulsoup4==4.5.3",
+        "requests>=2.10.0",
+        "beautifulsoup4>=4.4.0",
       ],
       entry_points="""
         # -*- Entry points: -*-

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import sys, os
 
-version = '1.3.1'
+version = '1.3.2'
 
 setup(name='webpreview',
       version=version,
@@ -10,7 +10,10 @@ setup(name='webpreview',
       classifiers=[
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
       ],
       keywords='OpenGraph TwitterCard Schema Facebook Twitter Google+',
       author='ludbek',

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py27, py330, py343, py350
 
 [testenv]
 deps=
-    requests==2.13.0
-    beautifulsoup4==4.5.3
+    requests>=2.10.0
+    beautifulsoup4>=4.4.0
 commands =
     python webpreview/test.py


### PR DESCRIPTION
This fixes **setup.py** and **tox.ini** according to Issue #10

Prevents PIP from complaining about upgrading requests module every time we want to update both **webpreview** and **requests** modules.

@ludbek in order for this to work, the package must be updated on PyPI.