### PR TITLE
Allows retrieval of absolute image URLs

### DIFF
--- a/test/generic-preview/h1-img-relative-path.html
+++ b/test/generic-preview/h1-img-relative-path.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width">
+        <title></title>
+    </head>
+    <body>
+        <div>
+            <h1>This title is from the first h1 tag.</h1>
+            <img src="/img/heck.jpg"></img>
+        </div>
+    </body>
+</html>

--- a/test/open-graph/available-img-relative-path.html
+++ b/test/open-graph/available-img-relative-path.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width">
+        <title></title>
+        <meta property="og:title" content="a title" />
+        <meta property="og:image" content="/img/heck.jpg" />
+        <meta property="og:price:amount" content="1" />
+    </head>
+    <body>
+    </body>
+</html>

--- a/test/schema/available-img-relative-path.html
+++ b/test/schema/available-img-relative-path.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width">
+        <title></title>
+        <meta itemprop="name" content="a title" />
+        <meta itemprop="camelCase" content="camelCase changed to camel_case." />
+        <meta itemprop="image" content="/img/heck.jpg" />
+    </head>
+    <body>
+    </body>
+</html>

--- a/test/twitter-card/available-img-relative-path.html
+++ b/test/twitter-card/available-img-relative-path.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width">
+        <title></title>
+        <meta name="twitter:title" content="a title" />
+        <meta name="twitter:description" content="a description" />
+        <meta name="twitter:image" content="/img/heck.jpg" />
+    </head>
+    <body>
+    </body>
+</html>

--- a/webpreview/helpers.py
+++ b/webpreview/helpers.py
@@ -1,0 +1,17 @@
+try:
+    from urlparse import urlparse, urlunparse  # Python2
+except ImportError:
+    from urllib.parse import urlparse, urlunparse  # Python3
+
+
+def process_image_url(request_url, image_url, force_absolute_url):
+    if not force_absolute_url:
+        return image_url
+
+    parsed_image_url = urlparse(image_url)
+
+    if not parsed_image_url.netloc and force_absolute_url:
+        scheme, netloc, path, *_ = urlparse(request_url)
+        path = image_url if image_url.startswith('/') else '{}{}'.format(path, image_url)
+        url_components = [scheme, netloc, path, None, None, None]
+        return urlunparse(url_components)

--- a/webpreview/helpers.py
+++ b/webpreview/helpers.py
@@ -11,7 +11,7 @@ def process_image_url(request_url, image_url, force_absolute_url):
     parsed_image_url = urlparse(image_url)
 
     if not parsed_image_url.netloc and force_absolute_url:
-        scheme, netloc, path, *_ = urlparse(request_url)
+        scheme, netloc, path, params, query, fragment = urlparse(request_url)
         path = image_url if image_url.startswith('/') else '{}{}'.format(path, image_url)
         url_components = [scheme, netloc, path, None, None, None]
         return urlunparse(url_components)

--- a/webpreview/previews.py
+++ b/webpreview/previews.py
@@ -4,8 +4,8 @@ import requests
 from requests.exceptions import *
 from bs4 import BeautifulSoup
 
-from excepts import *
-from helpers import process_image_url
+from .excepts import *
+from .helpers import process_image_url
 
 
 class PreviewBase(object):

--- a/webpreview/previews.py
+++ b/webpreview/previews.py
@@ -4,7 +4,8 @@ import requests
 from requests.exceptions import *
 from bs4 import BeautifulSoup
 
-from .excepts import *
+from excepts import *
+from helpers import process_image_url
 
 
 class PreviewBase(object):
@@ -32,7 +33,7 @@ class PreviewBase(object):
         try:
             res = requests.get(url, timeout=timeout, headers=headers)
         except (ConnectionError, HTTPError, Timeout, TooManyRedirects):
-            raise URLUnreachable("The URL does not exists.")
+            raise URLUnreachable("The URL does not exist.")
         except MissingSchema: # if no schema add http as default
             url = "http://" + url
 
@@ -43,7 +44,7 @@ class PreviewBase(object):
             raise URLUnreachable("The URL is unreachable.")
 
         if res.status_code == 404:
-            raise URLNotFound("The web page does not exists.")
+            raise URLNotFound("The web page does not exist.")
 
         # its safe to assign the url
         self.url = url
@@ -176,21 +177,21 @@ class Schema(SocialPreviewBase):
         super(Schema, self).__init__(*args, **kwargs)
 
 
-def web_preview(url, timeout=None, headers=None):
+def web_preview(url, timeout=None, headers=None, absolute_image_url=False):
     """
     Extract title, description and image from OpenGraph or TwitterCard or Schema or GenericPreview. Which ever returns first.
     """
     og = OpenGraph(url, ['og:title', 'og:description', 'og:image'], timeout=timeout, headers=headers)
     if og.title:
-        return og.title, og.description, og.image
+        return og.title, og.description, process_image_url(url, og.image, absolute_image_url)
 
     tc = TwitterCard(url, ['twitter:title', 'twitter:description', 'twitter:image'], timeout=timeout, headers=headers)
     if tc.title:
-        return tc.title, tc.description, tc.image
+        return tc.title, tc.description, process_image_url(url, tc.image, absolute_image_url)
 
     s = Schema(url, ['name', 'description', 'image'], timeout=timeout, headers=headers)
     if s.name:
-        return s.name, s.description, s.image
+        return s.name, s.description, process_image_url(url, s.image, absolute_image_url)
 
     gp = GenericPreview(url, timeout=timeout, headers=headers)
-    return gp.title, gp.description, gp.image
+    return gp.title, gp.description, process_image_url(url, gp.image, absolute_image_url)

--- a/webpreview/test.py
+++ b/webpreview/test.py
@@ -241,7 +241,7 @@ class TestWebPreview(unittest.TestCase):
         When a relative image path is found, the full absolute path is returned if the flag is True.
         """
         url = "http://localhost:8000/open-graph/available-img-relative-path.html"
-        title, description, image = web_preview(url, absolute_url=True)
+        title, description, image = web_preview(url, absolute_image_url=True)
         scheme, netloc, *_ = urlparse(url)
         base_url = '{}://{}'.format(scheme, netloc)
         self.assertTrue(image.startswith(base_url))
@@ -251,7 +251,7 @@ class TestWebPreview(unittest.TestCase):
         When a relative image path is found, the full absolute path is returned if the flag is True.
         """
         url = "http://localhost:8000/twitter-card/available-img-relative-path.html"
-        title, description, image = web_preview(url, absolute_url=True)
+        title, description, image = web_preview(url, absolute_image_url=True)
         scheme, netloc, *_ = urlparse(url)
         base_url = '{}://{}'.format(scheme, netloc)
         self.assertTrue(image.startswith(base_url))
@@ -261,7 +261,7 @@ class TestWebPreview(unittest.TestCase):
         When a relative image path is found, the full absolute path is returned if the flag is True.
         """
         url = "http://localhost:8000/schema/available-img-relative-path.html"
-        title, description, image = web_preview(url, absolute_url=True)
+        title, description, image = web_preview(url, absolute_image_url=True)
         scheme, netloc, *_ = urlparse(url)
         base_url = '{}://{}'.format(scheme, netloc)
         self.assertTrue(image.startswith(base_url))
@@ -271,7 +271,7 @@ class TestWebPreview(unittest.TestCase):
         When a relative image path is found, the full absolute path is returned if the flag is True.
         """
         url = "http://localhost:8000/generic-preview/h1-img-relative-path.html"
-        title, description, image = web_preview(url, absolute_url=True)
+        title, description, image = web_preview(url, absolute_image_url=True)
         scheme, netloc, *_ = urlparse(url)
         base_url = '{}://{}'.format(scheme, netloc)
         self.assertTrue(image.startswith(base_url))

--- a/webpreview/test.py
+++ b/webpreview/test.py
@@ -4,8 +4,8 @@ try:
 except ImportError:
     from urllib.parse import urlparse  # Python3
 
-from previews import *
-from excepts import *
+from webpreview.previews import *
+from webpreview.excepts import *
 
 class TestPreviewBase(unittest.TestCase):
     """

--- a/webpreview/test.py
+++ b/webpreview/test.py
@@ -1,7 +1,11 @@
 import unittest
+try:
+    from urlparse import urlparse  # Python2
+except ImportError:
+    from urllib.parse import urlparse  # Python3
 
-from webpreview.previews import *
-from webpreview.excepts import *
+from previews import *
+from excepts import *
 
 class TestPreviewBase(unittest.TestCase):
     """
@@ -162,7 +166,6 @@ class TestOpenGraph(unittest.TestCase):
         self.assertEqual(ogpreview.price_amount, None)
 
 
-
 class TestTwitterCard(unittest.TestCase):
     """
     Test TwitterCard.
@@ -209,7 +212,7 @@ class TestWebPreview(unittest.TestCase):
     """
     Test web_preview.
     """
-    def test_extracts_title_via_openg_graph(self):
+    def test_extracts_title_via_open_graph(self):
         """
         """
         title, description, image = web_preview("http://localhost:8000/open-graph/available.html")
@@ -232,6 +235,46 @@ class TestWebPreview(unittest.TestCase):
         """
         title, description, image = web_preview("http://localhost:8000/generic-preview/h1-p-desc.html")
         self.assertEqual(description, "This is valid description.")
+
+    def test_relative_image_path_returns_absolute_path_via_open_graph(self):
+        """
+        When a relative image path is found, the full absolute path is returned if the flag is True.
+        """
+        url = "http://localhost:8000/open-graph/available-img-relative-path.html"
+        title, description, image = web_preview(url, absolute_url=True)
+        scheme, netloc, *_ = urlparse(url)
+        base_url = '{}://{}'.format(scheme, netloc)
+        self.assertTrue(image.startswith(base_url))
+
+    def test_relative_image_path_returns_absolute_path_via_twitter_card(self):
+        """
+        When a relative image path is found, the full absolute path is returned if the flag is True.
+        """
+        url = "http://localhost:8000/twitter-card/available-img-relative-path.html"
+        title, description, image = web_preview(url, absolute_url=True)
+        scheme, netloc, *_ = urlparse(url)
+        base_url = '{}://{}'.format(scheme, netloc)
+        self.assertTrue(image.startswith(base_url))
+
+    def test_relative_image_path_returns_absolute_path_via_schema(self):
+        """
+        When a relative image path is found, the full absolute path is returned if the flag is True.
+        """
+        url = "http://localhost:8000/schema/available-img-relative-path.html"
+        title, description, image = web_preview(url, absolute_url=True)
+        scheme, netloc, *_ = urlparse(url)
+        base_url = '{}://{}'.format(scheme, netloc)
+        self.assertTrue(image.startswith(base_url))
+
+    def test_relative_image_path_returns_absolute_path_via_generic_preview(self):
+        """
+        When a relative image path is found, the full absolute path is returned if the flag is True.
+        """
+        url = "http://localhost:8000/generic-preview/h1-img-relative-path.html"
+        title, description, image = web_preview(url, absolute_url=True)
+        scheme, netloc, *_ = urlparse(url)
+        base_url = '{}://{}'.format(scheme, netloc)
+        self.assertTrue(image.startswith(base_url))
 
 
 if __name__ == '__main__':

--- a/webpreview/test.py
+++ b/webpreview/test.py
@@ -242,7 +242,7 @@ class TestWebPreview(unittest.TestCase):
         """
         url = "http://localhost:8000/open-graph/available-img-relative-path.html"
         title, description, image = web_preview(url, absolute_image_url=True)
-        scheme, netloc, *_ = urlparse(url)
+        scheme, netloc, path, params, query, fragment = urlparse(url)
         base_url = '{}://{}'.format(scheme, netloc)
         self.assertTrue(image.startswith(base_url))
 
@@ -252,7 +252,7 @@ class TestWebPreview(unittest.TestCase):
         """
         url = "http://localhost:8000/twitter-card/available-img-relative-path.html"
         title, description, image = web_preview(url, absolute_image_url=True)
-        scheme, netloc, *_ = urlparse(url)
+        scheme, netloc, path, params, query, fragment = urlparse(url)
         base_url = '{}://{}'.format(scheme, netloc)
         self.assertTrue(image.startswith(base_url))
 
@@ -262,7 +262,7 @@ class TestWebPreview(unittest.TestCase):
         """
         url = "http://localhost:8000/schema/available-img-relative-path.html"
         title, description, image = web_preview(url, absolute_image_url=True)
-        scheme, netloc, *_ = urlparse(url)
+        scheme, netloc, path, params, query, fragment = urlparse(url)
         base_url = '{}://{}'.format(scheme, netloc)
         self.assertTrue(image.startswith(base_url))
 
@@ -272,7 +272,7 @@ class TestWebPreview(unittest.TestCase):
         """
         url = "http://localhost:8000/generic-preview/h1-img-relative-path.html"
         title, description, image = web_preview(url, absolute_image_url=True)
-        scheme, netloc, *_ = urlparse(url)
+        scheme, netloc, path, params, query, fragment = urlparse(url)
         base_url = '{}://{}'.format(scheme, netloc)
         self.assertTrue(image.startswith(base_url))
 


### PR DESCRIPTION
Solves #9 .

```
>>> from webpreview import web_preview
>>> web_preview('https://understand.ai')
('understand.ai', 'High quality image annotation to boost your machine learning algorithms.', 'images/banner.png')
>>> web_preview('https://understand.ai', absolute_image_url=True)
('understand.ai', 'High quality image annotation to boost your machine learning algorithms.', 'https://understand.ai/images/banner.png')
```

Also did some typo fixes.