### PR TITLE
Dockerized the library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3
+
+WORKDIR /usr/src/app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD [ "python", "./setup.py" ]

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Webpreview helps preview a webpage. It extracts [Open Graph](http://ogp.me/), [T
 
     $ pip install webpreview
 
+## Run with Docker
+    $ docker build -t webpreview:1.6.0 .
+    $ docker run -it --rm --name webpreview webpreview:1.6.0 python
+    
 #Usage
 ## Preview a Web Page
 API: `web_preview(url, timeout?, headers?, content?, absolute_image_url?, parser?)`

--- a/README.md
+++ b/README.md
@@ -8,9 +8,12 @@ Webpreview helps preview a webpage. It extracts [Open Graph](http://ogp.me/), [T
     $ pip install webpreview
 
 ## Run with Docker
-    $ docker build -t webpreview:1.6.0 .
-    $ docker run -it --rm --name webpreview webpreview:1.6.0 python
-    
+    $ docker build -t webpreview .
+    $ docker run -it --rm --name webpreview webpreview python
+
+### Run your script
+    $ docker run -it --rm --name my-script -v "$PWD":/usr/src/myapp -w /usr/src/myapp webpreview python your-script.py
+
 #Usage
 ## Preview a Web Page
 API: `web_preview(url, timeout?, headers?, content?, absolute_image_url?, parser?)`


### PR DESCRIPTION
Below are the usages:
- Users who want to deploy this as a docker containers or as FaaS can just build image and push to their repositories and use across Docker Swarm cluster or in Kubernetis clusters
- Without installing python, with just docker installed they can explore the library
- Release webpreview as docker image to the docker marketplace(s)